### PR TITLE
[portorch] Support new interface types CR8/SR8/KR8/LR8 which are brought by SAI V.1.10.2

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -118,12 +118,16 @@ static map<string, sai_port_interface_type_t> interface_type_map =
  { "none", SAI_PORT_INTERFACE_TYPE_NONE },
  { "cr", SAI_PORT_INTERFACE_TYPE_CR },
  { "cr4", SAI_PORT_INTERFACE_TYPE_CR4 },
+ { "cr8", SAI_PORT_INTERFACE_TYPE_CR8 },
  { "sr", SAI_PORT_INTERFACE_TYPE_SR },
  { "sr4", SAI_PORT_INTERFACE_TYPE_SR4 },
+ { "sr8", SAI_PORT_INTERFACE_TYPE_SR8 },
  { "lr", SAI_PORT_INTERFACE_TYPE_LR },
  { "lr4", SAI_PORT_INTERFACE_TYPE_LR4 },
+ { "lr8", SAI_PORT_INTERFACE_TYPE_LR8 },
  { "kr", SAI_PORT_INTERFACE_TYPE_KR },
- { "kr4", SAI_PORT_INTERFACE_TYPE_KR4 }
+ { "kr4", SAI_PORT_INTERFACE_TYPE_KR4 },
+ { "kr8", SAI_PORT_INTERFACE_TYPE_KR8 }
 };
 
 // Interface type map used for auto negotiation
@@ -133,13 +137,17 @@ static map<string, sai_port_interface_type_t> interface_type_map_for_an =
     { "cr", SAI_PORT_INTERFACE_TYPE_CR },
     { "cr2", SAI_PORT_INTERFACE_TYPE_CR2 },
     { "cr4", SAI_PORT_INTERFACE_TYPE_CR4 },
+    { "cr8", SAI_PORT_INTERFACE_TYPE_CR8 },
     { "sr", SAI_PORT_INTERFACE_TYPE_SR },
     { "sr2", SAI_PORT_INTERFACE_TYPE_SR2 },
     { "sr4", SAI_PORT_INTERFACE_TYPE_SR4 },
+    { "sr8", SAI_PORT_INTERFACE_TYPE_SR8 },
     { "lr", SAI_PORT_INTERFACE_TYPE_LR },
     { "lr4", SAI_PORT_INTERFACE_TYPE_LR4 },
+    { "lr8", SAI_PORT_INTERFACE_TYPE_LR8 },
     { "kr", SAI_PORT_INTERFACE_TYPE_KR },
     { "kr4", SAI_PORT_INTERFACE_TYPE_KR4 },
+    { "kr8", SAI_PORT_INTERFACE_TYPE_KR8 },
     { "caui", SAI_PORT_INTERFACE_TYPE_CAUI },
     { "gmii", SAI_PORT_INTERFACE_TYPE_GMII },
     { "sfi", SAI_PORT_INTERFACE_TYPE_SFI },


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Support new interface types CR8/SR8/KR8/LR8.

**Why I did it**

SAI V.1.10.2 introduced new interface types CR8/SR8/KR8/LR8, they shall be added to `interface_type_map` and `interface_type_map_for_an`.

**How I verified it**

config from CLI, new interface types can be accepted and correctly passed to SAI.

**Details if related**
